### PR TITLE
fix: cantina issue #4

### DIFF
--- a/contracts/ERC20Paymaster.sol
+++ b/contracts/ERC20Paymaster.sol
@@ -56,6 +56,7 @@ contract ERC20Paymaster is IPaymaster, Ownable {
     }
 
     constructor(address _verifier) {
+        if (_verifier == address(0)) revert Errors.InvalidAddress();
         verifier = _verifier;
         emit VerifierChanged(_verifier);
     }
@@ -226,6 +227,7 @@ contract ERC20Paymaster is IPaymaster, Ownable {
      * @param _newVerifier The new verifier address.
      */
     function setVerifier(address _newVerifier) external onlyOwner {
+        if (_newVerifier == address(0)) revert Errors.InvalidAddress();
         verifier = _newVerifier;
         emit VerifierChanged(_newVerifier);
     }

--- a/contracts/ERC20SponsorPaymaster.sol
+++ b/contracts/ERC20SponsorPaymaster.sol
@@ -73,6 +73,7 @@ contract ERC20SponsorPaymaster is IPaymaster, Ownable {
     }
 
     constructor(address _verifier) {
+        if (_verifier == address(0)) revert Errors.InvalidAddress();
         verifier = _verifier;
         // Set the default markup to +0%
         defaultMarkup = 1e4;
@@ -312,6 +313,7 @@ contract ERC20SponsorPaymaster is IPaymaster, Ownable {
      * @param _newVerifier The new verifier address.
      */
     function setVerifier(address _newVerifier) external onlyOwner {
+        if (_newVerifier == address(0)) revert Errors.InvalidAddress();
         verifier = _newVerifier;
         emit VerifierChanged(_newVerifier);
     }

--- a/test/development/ERC20Paymaster.test.ts
+++ b/test/development/ERC20Paymaster.test.ts
@@ -360,5 +360,9 @@ describe("ERC20Paymaster", () => {
         );
       }
     });
+    it("Should fail when setting verifier to zero address", async () => {
+      expect(paymaster.connect(admin).setVerifier(ethers.constants.AddressZero))
+        .to.be.rejected;
+    });
   });
 });


### PR DESCRIPTION
Context: [ERC20Paymaster.sol#L58-L61](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L58-L61), [ERC20Paymaster.sol#L228-L231](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L228-L231), [ERC20SponsorPaymaster.sol#L75-L81](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L75-L81), [ERC20SponsorPaymaster.sol#L314-L317](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L314-L317)

Description: If the verifier is set to address(0) the signature validation in validateAndPayForPaymasterTransaction will always revert.

Recommendation: This may be desirable as a way of shutting off the paymaster contract, but assuming the preferred way of doing upstream from the paymaster, consider adding a if (_verifier == address(0)) revert Errors.InvalidAddress(); check to the appropriate places.

Zyfi: Agreed. Our plan to shut off a paymaster is not dependent on this, so we will add the protection.