### PR TITLE
feat: cantina issue #6

### DIFF
--- a/contracts/SponsorshipVault.sol
+++ b/contracts/SponsorshipVault.sol
@@ -42,7 +42,9 @@ contract SponsorshipVault {
      */
     function depositToAccount(address account) public payable {
         if (account == address(0)) revert Errors.InvalidAddress();
-        balances[account] += msg.value;
+        unchecked {
+            balances[account] += msg.value;
+        }
         emit Deposited(account, msg.value);
     }
 
@@ -55,7 +57,9 @@ contract SponsorshipVault {
      */
     function withdraw(uint256 amount) public {
         if (amount > balances[msg.sender]) revert Errors.NotEnoughFunds();
-        balances[msg.sender] -= amount;
+        unchecked {
+            balances[msg.sender] -= amount;
+        }
         (bool sent, ) = payable(msg.sender).call{value: amount}("");
         if (!sent) revert Errors.FailedWithdrawal();
         emit Withdrawn(msg.sender, amount);
@@ -74,7 +78,9 @@ contract SponsorshipVault {
         uint256 amount
     ) public onlyPaymaster {
         if (amount > balances[account]) revert Errors.NotEnoughFunds();
-        balances[account] -= amount;
+        unchecked {
+            balances[account] -= amount;
+        }
         (bool sent, ) = payable(paymaster).call{value: amount}("");
         if (!sent) revert Errors.FailedTransferToPaymaster();
         emit paidSponsorship(account, amount);
@@ -86,7 +92,9 @@ contract SponsorshipVault {
      * @dev Only the paymaster is allowed to call this function, to allow for easier tracking
      */
     function refundSponsorship(address account) public payable onlyPaymaster {
-        balances[account] += msg.value;
+        unchecked {
+            balances[account] += msg.value;
+        }
         emit refundedSponsorship(account, msg.value);
     }
 


### PR DESCRIPTION
> **Context:** [ERC20Paymaster.sol#L50-L56](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L50-L56), [ERC20SponsorPaymaster.sol#L67-L73](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L67-L73), [SponsorshipVault.sol#L32-L35](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/SponsorshipVault.sol#L32-L35), [SponsorshipVault.sol](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/SponsorshipVault.sol), [ERC20Paymaster.sol#L41](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L41), [ERC20SponsorPaymaster.sol#L38-L41](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L38-L41)
> 
> **Description:**
> 
> * **Modifiers:**
>   
>   * [ERC20Paymaster.sol#L50-L56](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L50-L56)
>   * [ERC20SponsorPaymaster.sol#L67-L73](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L67-L73)
>   * [SponsorshipVault.sol#L32-L35](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/SponsorshipVault.sol#L32-L35)
>   
>   Generally in Ethereum, there are some gas savings by moving modifier code from the modifier into a function.  Since when a contract is deployed, the modifier code is copied into each function that uses it, this reduces the size of the code.
> * **Safe/Unchecked Math**:
>   
>   * [SponsorshipVault.sol](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/SponsorshipVault.sol)
>   
>   In the `SponsorshipVault` all of the math operations (adding and subtracting from sponsor balances) should be able to be wrapped in `unchecked` blocks.  Where the user is depositing or the Paymaster is refunding, that addition cannot approach `type(uint256).max` since it is dealing with ETH and `msg.value`.  The subtraction functions will already revert with `Errors.NotEnoughFunds()` if the amount to be subtracted is greater than the balance of the `msg.sender`.
> * **Constants:**
>   
>   * [ERC20Paymaster.sol#L41](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20Paymaster.sol#L41)
>   * [ERC20SponsorPaymaster.sol#L38-L41](https://github.com/ondefy/zyfi-paymaster/blob/cantina-audit/contracts/ERC20SponsorPaymaster.sol#L38-L41)
>   
>   The zkSync Era's documentation on [design recommendations](https://docs.zksync.io/build/developer-reference/fee-model.html#design-recommendations) specifically calls out a scenario where it is better to reuse contract code and provides the example that constants are the better thing to do with Ethereum, but passing constructor parameters instead in Era "_leads to substantial fee savings_".
> 
> **Recommendation:** We recommend you test the effects of these changes in the zkSync environment to ensure they provide gas savings in Era.
> 
> * Example code for modifiers:
>   ```solidity
>   modifier onlyBootloader() {
>       _checkBootloader();
>       // Continue execution if called from the bootloader.
>       _;
>   }
>   
>   function _checkBootloader() internal view {
>       if (msg.sender != BOOTLOADER_FORMAL_ADDRESS) {
>           revert Errors.NotFromBootloader();
>       }
>   }
>   ```
> * Example for the `unchecked`:
>   ```solidity
>   function withdraw(uint256 amount) public {
>       if (amount > balances[msg.sender]) revert Errors.NotEnoughFunds();
>           unchecked {
>               balances[msg.sender] -= amount;
>           }
>       (bool sent, ) = payable(msg.sender).call{value: amount}("");
>       if (!sent) revert Errors.FailedWithdrawal();
>       emit Withdrawn(msg.sender, amount);
>   }
>   ```
> * For the Constants:
>   The added complexity of having to pass the `NOMINATOR`s and `version` seems a little awkward; however, we would recommend at least trying the change in your environment and evaluating if the gas savings warrants making the change (and whether the savings is only on contract deploy or also in transactions since the latter is much more important for this use case).


We didn't notice gas savings when changing the modifiers or the constant deployment, but we will keep them in mind for future iterations.

We implemented the unchecked sections.